### PR TITLE
Allow custom request and response model factories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ fabric.properties
 
 # Virtual env
 .venv*
+/venv

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Silk is a live profiling and inspection tool for the Django framework. Silk inte
   * [Meta-Profiling](#meta-profiling)
   * [Recording a fraction of requests](#recording-a-fraction-of-requests)
   * [Limiting request/response data](#limiting-requestresponse-data)
+  * [Using custom classes](#using-custom-classes)
   * [Clearing logged data](#clearing-logged-data)
 * [Contributing](#contributing)
   * [Development Environment](#development-environment)
@@ -463,6 +464,24 @@ The garbage collection is only run on a percentage of requests to reduce overhea
 ```python
 SILKY_MAX_RECORDED_REQUESTS_CHECK_PERCENT = 10
 ```
+
+### Using custom classes
+
+Sometimes it's handy to configure custom classes to handle requests or responses.
+
+You can replace request model factory class with this setting:
+```python
+SILKY_REQUEST_MODEL_FACTORY_CLASS = 'path.to.CustomRequestModelFactory'
+```
+It's recommended to create custom classes that inherit from `silk.model_factory.RequestModelFactory`.
+
+
+You can replace response model factory class with this setting:
+```python
+SILKY_RESPONSE_MODEL_FACTORY_CLASS = 'path.to.CustomResponseModelFactory'
+```
+It's recommended to create custom classes that inherit from `silk.model_factory.ResponseModelFactory`.
+
 
 ### Clearing logged data
 

--- a/project/tests/test_config_classes.py
+++ b/project/tests/test_config_classes.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from silk.config import SilkyConfig
+from silk.model_factory import RequestModelFactory, ResponseModelFactory
+
+
+class DummyRequestModelFactory(RequestModelFactory):
+    pass
+
+
+class DummyResponseModelFactory(ResponseModelFactory):
+    pass
+
+
+class TestRequestModelFactoryClass(TestCase):
+
+    def test_config_with_no_value_should_have_default(self):
+        config = SilkyConfig()
+        self.assertEqual(config.SILKY_REQUEST_MODEL_FACTORY_CLASS, 'silk.model_factory.RequestModelFactory')
+
+    def test_config_with_no_value_should_have_request_model_factory_property(self):
+        config = SilkyConfig()
+        self.assertTrue(hasattr(config, 'request_model_factory'))
+
+    @patch.dict(SilkyConfig().attrs, {
+        'SILKY_REQUEST_MODEL_FACTORY_CLASS': 'tests.test_config_classes.DummyRequestModelFactory'
+    })
+    def test_config_with_custom_class_should_load_custom_class(self):
+        config = SilkyConfig()
+        self.assertIs(config.request_model_factory, DummyRequestModelFactory)
+
+
+class TestResponseModelFactoryClass(TestCase):
+
+    def test_config_with_no_value_should_have_default(self):
+        config = SilkyConfig()
+        self.assertEqual(config.SILKY_RESPONSE_MODEL_FACTORY_CLASS, 'silk.model_factory.ResponseModelFactory')
+
+    def test_config_with_no_value_should_have_response_model_factory_property(self):
+        config = SilkyConfig()
+        self.assertTrue(hasattr(config, 'response_model_factory'))
+
+    @patch.dict(SilkyConfig().attrs, {
+        'SILKY_RESPONSE_MODEL_FACTORY_CLASS': 'tests.test_config_classes.DummyResponseModelFactory'
+    })
+    def test_config_with_custom_class_should_load_custom_class(self):
+        config = SilkyConfig()
+        self.assertIs(config.response_model_factory, DummyResponseModelFactory)
+

--- a/silk/config.py
+++ b/silk/config.py
@@ -29,7 +29,9 @@ class SilkyConfig(six.with_metaclass(Singleton, object)):
         'SILKY_INTERCEPT_FUNC': None,
         'SILKY_PYTHON_PROFILER': False,
         'SILKY_STORAGE_CLASS': 'silk.storage.ProfilerResultStorage',
-        'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware'
+        'SILKY_MIDDLEWARE_CLASS': 'silk.middleware.SilkyMiddleware',
+        'SILKY_REQUEST_MODEL_FACTORY_CLASS': 'silk.model_factory.RequestModelFactory',
+        'SILKY_RESPONSE_MODEL_FACTORY_CLASS': 'silk.model_factory.ResponseModelFactory',
     }
 
     def _setup(self):
@@ -39,6 +41,20 @@ class SilkyConfig(six.with_metaclass(Singleton, object)):
         self.attrs = copy(self.defaults)
         self.attrs['SILKY_PYTHON_PROFILER_RESULT_PATH'] = settings.MEDIA_ROOT
         self.attrs.update(options)
+
+    @property
+    def request_model_factory(self):
+        from importlib import import_module
+        mod_name, cls_name = self.SILKY_REQUEST_MODEL_FACTORY_CLASS.rsplit('.', 1)
+        mod = import_module(mod_name)
+        return getattr(mod, cls_name)
+
+    @property
+    def response_model_factory(self):
+        from importlib import import_module
+        mod_name, cls_name = self.SILKY_RESPONSE_MODEL_FACTORY_CLASS.rsplit('.', 1)
+        mod = import_module(mod_name)
+        return getattr(mod, cls_name)
 
     def __init__(self):
         super(SilkyConfig, self).__init__()

--- a/silk/middleware.py
+++ b/silk/middleware.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 from silk.collector import DataCollector
 
 from silk.config import SilkyConfig
-from silk.model_factory import RequestModelFactory, ResponseModelFactory
 from silk.profiling import dynamic
 from silk.profiling.profiler import silk_meta_profiler
 from silk.sql import execute_sql
@@ -104,7 +103,7 @@ class SilkyMiddleware:
         if not hasattr(SQLCompiler, '_execute_sql'):
             SQLCompiler._execute_sql = SQLCompiler.execute_sql
             SQLCompiler.execute_sql = execute_sql
-        request_model = RequestModelFactory(request).construct_request_model()
+        request_model = SilkyConfig().request_model_factory(request).construct_request_model()
         DataCollector().configure(request_model)
 
     @transaction.atomic()
@@ -115,7 +114,7 @@ class SilkyMiddleware:
             collector.stop_python_profiler()
             silk_request = collector.request
             if silk_request:
-                silk_response = ResponseModelFactory(response).construct_response_model()
+                silk_response = SilkyConfig().response_model_factory(response).construct_response_model()
                 silk_response.save()
                 silk_request.end_time = timezone.now()
                 collector.finalise()


### PR DESCRIPTION
Sometimes, it's needed custom factories for request and
response models to handle incoming request in the
middleware. You could solve this by extending the
middleware but probably end up copying a lot of code.
With this development, you can configure custom classes
to solve this.

`SILKY_REQUEST_MODEL_FACTORY_CLASS` and
`SILKY_RESPONSE_MODEL_FACTORY_CLASS` are settings that
allow customization of factories.